### PR TITLE
Adds a DER model wrapper

### DIFF
--- a/examples/config_der.json
+++ b/examples/config_der.json
@@ -1,6 +1,6 @@
 {
 "50":{"parent_config":"",
-      "basic_specs":{"n_phases":3},
+      "basic_specs":{"model_type":"SolarPVDERThreePhase"},
       "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0},
                           
@@ -22,7 +22,7 @@
      },
 
     "250":{"parent_config":"",
-          "basic_specs":{"n_phases":3},
+          "basic_specs":{"model_type":"SolarPVDERThreePhase"},
           "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":45,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 750.0,"Vdcmpp_max": 1000.0},
                           
@@ -41,7 +41,7 @@
      },
 
 "10":{"parent_config":"",
-      "basic_specs":{"n_phases":1},
+      "basic_specs":{"model_type":"SolarPVDERSinglePhase"},
       "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
       
@@ -59,8 +59,26 @@
                         "xDC":0.0,"xQ":0.0,"xPLL":0.0,"wte":6.28}
       
      },
+"50_balanced":{"parent_config":"",
+      "basic_specs":{"model_type":"SolarPVDERThreePhaseBalanced"},
+      "basic_options":{"Sinsol":100.0},
+      "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0},
+                          
+      "inverter_ratings":{"Srated":50e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
+      
+      "circuit_parameters":{"Rf_actual":0.002,"Lf_actual":25.0e-6,
+                            "C_actual":300.0e-6,"R1_actual":0.0019,"X1_actual":0.0561},
+      
+      "controller_gains":{"Kp_GCC":6000.0,"Ki_GCC":2000.0,
+                          "Kp_DC":-2.0,"Ki_DC":-10.0,
+                          "Kp_Q":0.2,"Ki_Q":10.0,"wp": 20e4},
+      
+      "steadystate_values":{"maR0":0.89,"maI0":0.0,"iaR0":1.0,"iaI0":0.001},
+      "initial_states":{"iaR":0,"iaI":0.0,"xaR":0.0,"xaI":0.0,"uaR":0.0,"uaI":0.0,
+                        "xDC":0.0,"xQ":0.0,"xPLL":0.0,"wte":6.28}
+     },
 "10_constantVdc":{"parent_config":"",
-                  "basic_specs":{"n_phases":1},
+                  "basic_specs":{"model_type":"SolarPVDERSinglePhaseConstantVdc"},
                   "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
       
@@ -78,10 +96,25 @@
                         "xDC0":0.0,"xQ0":0.0,"xPLL0":0.0,"wte0":6.28}
       
      },
+     
+"50_constantVdc":{"parent_config":"",
+                  "basic_specs":{"model_type":"SolarPVDERThreePhaseConstantVdc"},
+                  "basic_options":{"Sinsol":100.0},
+                  "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0}, 
+                  "inverter_ratings":{"Srated":50e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
+                  "circuit_parameters":{"Rf_actual":0.002,"Lf_actual":25.0e-6,"R1_actual":0.0019,"X1_actual":0.0561},
+                  "controller_gains":{"Kp_GCC":6000.0,"Ki_GCC":2000.0,"Kp_P":500.0,"Ki_P":50.0,"Kp_Q":0.2,"Ki_Q":10.0,"wp": 20e4},
+                  "steadystate_values":{"maR0":0.89,"maI0":0.0,"iaR0":1.0,"iaI0":0.001},
+                  "initial_states":{"iaR":0,"iaI":0.0,"xaR":0.0,"xaI":0.0,"uaR":0.0,"uaI":0.0,
+                                    "ibR":0,"ibI":0.0,"xbR":0.0,"xbI":0.0,"ubR":0.0,"ubI":0.0,
+                                    "icR":0,"icI":0.0,"xcR":0.0,"xcI":0.0,"ucR":0.0,"ucI":0.0,
+                                    "xP":0.0,"xQ":0.0,
+                                    "xPLL":0.0,"wte":6.28}
+                },   
     
 "1":{"parent_config":"",
-     "basic_specs":{"n_phases":1,"Sinsol":100.0},
-    
+     "basic_specs":{"model_type":"SolarPVDERSinglePhase"},
+     "basic_options":{"Sinsol":100.0},
      "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
      "inverter_ratings":{"Srated":10e3,"Varated":250.0,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
      

--- a/examples/config_td.json
+++ b/examples/config_td.json
@@ -20,6 +20,7 @@
                     "DERFilePath": "..\\examples\\config_der.json",
                     "initializeWithActual":true,
                     "DERSetting":"PVPlacement",
+                    "DERModelType":"ThreePhaseUnbalanced",
                     "DERParameters":{
                         "default":{
                         "solarPenetration":0.01,

--- a/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
@@ -9,7 +9,8 @@ import math
 
 from tdcosim.model.opendss.opendss_data import OpenDSSData
 from tdcosim.model.opendss.model.pvderaggregation.procedure.pvder_procedure import PVDERProcedure
-from pvder.DER_components_three_phase  import SolarPVDERThreePhase
+from pvder.DER_wrapper import DERModel
+
 from pvder.simulation_events import SimulationEvents
 from pvder import utility_functions
 

--- a/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
@@ -9,7 +9,7 @@ import math
 
 from tdcosim.model.opendss.opendss_data import OpenDSSData
 from tdcosim.model.opendss.model.pvderaggregation.procedure.pvder_procedure import PVDERProcedure
-from pvder.DER_components_three_phase  import SolarPV_DER_ThreePhase
+from pvder.DER_components_three_phase  import SolarPVDERThreePhase
 from pvder.simulation_events import SimulationEvents
 from pvder import utility_functions
 
@@ -32,20 +32,21 @@ class PVDERAggregatedModel:
         """
 
         DERFilePath = OpenDSSData.config['myconfig']['DERFilePath']
-        
+        DERModelType = OpenDSSData.config['myconfig']['DERModelType']                
+                        
         Va = cmath.rect(voltageRating*math.sqrt(2),0.0)
         Vb = utility_functions.Ub_calc(Va)
         Vc = utility_functions.Uc_calc(Va)
-
-        DER_model = SolarPV_DER_ThreePhase(events=SimulationEvents(),configFile=DERFilePath,
-                                          powerRating = powerRating*1e3,
-                                          VrmsRating = voltageRating,
-                                          gridVoltagePhaseA = Va,
-                                          gridVoltagePhaseB = Vb,
-                                          gridVoltagePhaseC = Vc,
-                                          gridFrequency=2*math.pi*60.0,
-                                          standAlone=False,steadyStateInitialization=True)
-
+        
+        PVDER_model = DERModel(modelType=DERModelType,events=events,configFile=DERFilePath,
+                               powerRating = powerRating*1e3,VrmsRating = voltageRating,
+                               gridVoltagePhaseA = Va,
+                               gridVoltagePhaseB = Vb,
+                               gridVoltagePhaseC = Vc,
+                               gridFrequency=2*math.pi*60.0,
+                               standAlone=False,steadyStateInitialization=True)     
+        self.PV_model = PVDER_model.DER_model
+        
         return DER_model.S_PCC.real*DER_model.Sbase,DER_model.S_PCC.imag*DER_model.Sbase    
     
     def setup(self, S0, V0):

--- a/tdcosim/model/opendss/model/pvderaggregation/model/pvder_model.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/pvder_model.py
@@ -7,10 +7,7 @@ import logging
 
 from tdcosim.model.opendss.opendss_data import OpenDSSData
 
-from pvder.DER_components_single_phase import SolarPVDERSinglePhase
-from pvder.DER_components_three_phase  import SolarPVDERThreePhase
 from pvder.DER_wrapper import DERModel
-
 from pvder.grid_components import Grid
 from pvder.dynamic_simulation import DynamicSimulation
 from pvder.simulation_events import SimulationEvents


### PR DESCRIPTION
Uses a model wrapper class to select the appropriate DER model type for use with the co-simulation.
The model type can be specified through `"DERModelType":` field in the co-simulation config file. All DER models in a feeder will be of the same model type but different feeders can have different model types.