### PR TITLE
Updates to enable usage of SciPy Adams method for Fast DER models

### DIFF
--- a/tdcosim/model/opendss/model/pvderaggregation/model/fast_der.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/fast_der.py
@@ -264,11 +264,10 @@ class FastDER(object):
 			raise
 
 #===================================================================================================
-	def func_val_new(self,x,t):
+	def func_val_combined(self,x,t):
 		try:
-			vmag=x[3]
-			self.ride_through_logic(vmag=vmag,dt=1/120.)
-			recompute_initial_condition= False #self.enter_service(dt=dt)
+			
+			recompute_initial_condition= False #self.enter_service(dt=1/120.)
 			flags=self._ride_through_flags
 			
 			if flags['momentary_cessation'] or flags['trip']:
@@ -279,21 +278,18 @@ class FastDER(object):
 				self.data['config']['pref']=0
 				self.data['config']['qref']=0
 				self.x=x*0.0 # will not integrate
-				# to sync with global time
-				#self._integrator_data['time_values'].append(self._integrator_data['time_values'][-1]+dt)
 				self._integrator_data['time_values'].append(t)
+				
 			else:
 				if recompute_initial_condition:
 					self.compute_initial_condition(self.data['config']['pref'],\
 					self.data['config']['qref'],self.data['model']['vt'],\
 					self.data['model']['vt_angle'])
-
-				#self.x=self.x+dt*self.func_val(self.x)
+				self.x=x
 				self.f = self.func_val(x)
-				#self._integrator_data['time_values'].append(self._integrator_data['time_values'][-1]+dt)
 				self._integrator_data['time_values'].append(t)
-			
-			return self.x
+				
+			return self.f
 		except:
 			raise
 
@@ -366,6 +362,7 @@ class FastDER(object):
 						flags[rts['lvrt'][thisZone]['action']]=True
 					if thisVmin<=vmag<thisVmax:
 						rts['lvrt'][thisZone]['time_in_zone']+=dt
+					
 			elif vmag>rts['normal_operation']['voltage_range'][1]:# abnormal HV operation
 				for thisZone in rts['hvrt']:
 					thisVmin,thisVmax=rts['lvrt'][thisZone]['voltage_range']

--- a/tdcosim/model/opendss/model/pvderaggregation/model/fast_der.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/fast_der.py
@@ -7,7 +7,7 @@ import inspect
 import tdcosim
 import numpy as np
 from scipy.optimize import fsolve
-
+from tdcosim.model.opendss.opendss_data import OpenDSSData
 
 class FastDER(object):
 	"""Sample call: 
@@ -252,7 +252,7 @@ class FastDER(object):
 			model['dw']=0
 
 			# init condition
-			self.x=[0,model['pref'],model['pref']/model['vt'],
+			self.x=[0.0,model['pref'],model['pref']/model['vt'],
 			model['vt'],-model['qref']/model['vt'],-model['qref']/model['vt']]
 			if model['modelname']=='m2':
 				self.x.append(model['pref'])
@@ -260,6 +260,40 @@ class FastDER(object):
 
 			# update model
 			self.update_model(vt*(np.cos(vt_ang)+1j*np.sin(vt_ang)))
+		except:
+			raise
+
+#===================================================================================================
+	def func_val_new(self,x,t):
+		try:
+			vmag=x[3]
+			self.ride_through_logic(vmag=vmag,dt=1/120.)
+			recompute_initial_condition= False #self.enter_service(dt=dt)
+			flags=self._ride_through_flags
+			
+			if flags['momentary_cessation'] or flags['trip']:
+				if not self.data['config']['pref_predisturbance']:
+					self.data['config']['pref_predisturbance']=self.data['config']['pref']
+				if not self.data['config']['qref_predisturbance']:
+					self.data['config']['qref_predisturbance']=self.data['config']['qref']
+				self.data['config']['pref']=0
+				self.data['config']['qref']=0
+				self.x=x*0.0 # will not integrate
+				# to sync with global time
+				#self._integrator_data['time_values'].append(self._integrator_data['time_values'][-1]+dt)
+				self._integrator_data['time_values'].append(t)
+			else:
+				if recompute_initial_condition:
+					self.compute_initial_condition(self.data['config']['pref'],\
+					self.data['config']['qref'],self.data['model']['vt'],\
+					self.data['model']['vt_angle'])
+
+				#self.x=self.x+dt*self.func_val(self.x)
+				self.f = self.func_val(x)
+				#self._integrator_data['time_values'].append(self._integrator_data['time_values'][-1]+dt)
+				self._integrator_data['time_values'].append(t)
+			
+			return self.x
 		except:
 			raise
 

--- a/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
+++ b/tdcosim/model/opendss/model/pvderaggregation/model/pvder_aggregated_model.py
@@ -261,7 +261,7 @@ class PVDERAggregatedModel(object):
 				self.integrator=ode(self.funcval_fastder).set_integrator('vode',method='adams',max_step=1/240.,rtol=1e-4,atol=1e-4)
 				self.integrator.set_initial_value(y0,t0)
 				OpenDSSData.log(level=10,msg="FastDER model integrator using Adams method initialized at {:.3f} seconds".format(time.time()))
-				OpenDSSData.log(level=10,msg="FastDER model: initial ,y0:{}".format(y0))
+				
 			else:
 				OpenDSSData.log(level=10,msg="FastDER model integrator using {} initialized at {:.3f} seconds".format(self.ode_solver_method,time.time()))
 			
@@ -540,7 +540,7 @@ class PVDERAggregatedModel(object):
 
 						# update Voltage injection
 						thisPV.update_model(Va)
-						OpenDSSData.log(level=10,msg="FastDER model: updated steady state y0,{}:{}".format(pvID,thisPV.x))
+						
 						# integrate
 						thisPV.integrate(dt=dt)
 						thisId=thisPV.x[2]
@@ -554,7 +554,7 @@ class PVDERAggregatedModel(object):
 						if pv not in x[node]:
 							x[node][pv]={}
 						x[node][pv]=copy.deepcopy(thisPV.x).tolist()
-				OpenDSSData.log(level=10,msg="t:{},node: {} P:{}".format(thisT,node,nodeP))
+				
 				P[node]=nodeP
 				Q[node]=nodeQ
 				OpenDSSData.data['DNet']['DER']['PVDERData'][node]['Vmag']['a']=Va


### PR DESCRIPTION
Adams method can be used by using ` "DEROdeMethod": "adams"` in config file.
The results using Adams were compared with the earlier results from Euler and found to be matching.

Note: `recompute_initial_condition `is set to False (will be fixed later) when using Adams method.

![fast_der_comparison_1](https://user-images.githubusercontent.com/25213730/148143508-09866485-27ab-411b-8dc7-11926f0eb8c7.png)

![fast_der_comparison_fault](https://user-images.githubusercontent.com/25213730/148143526-e146eb9f-6abd-4dac-809f-a458a318b86b.png)
