### PR TITLE
Add port number as optional argument when launching dashboard

### DIFF
--- a/tdcosim/dashboard/app.py
+++ b/tdcosim/dashboard/app.py
@@ -573,6 +573,7 @@ if __name__ == '__main__':
 	# # init
 	nFiles = int(sys.argv[4])
 	useDask = sys.argv[5]
+	portNumber = int(sys.argv[6])
 	
 	tic = time.time()
 	if os.path.isfile(sys.argv[1]):
@@ -657,6 +658,6 @@ if __name__ == '__main__':
 	app.layout=html.Div(objects['tabs']['main_tab'],
 	style={'width':'99vw','height':'98vh','background-color':colorobj[0]})
 	toc = time.time()
-	print("Time taken to load and process dataframe:{:.2f} s".format(toc - tic))
+	print("Time taken to load and process dataframe on port:{}:{:.2f} s".format(portNumber,toc - tic))
 	# run
-	app.run_server(debug=False,use_reloader=False)
+	app.run_server(port=portNumber,debug=False,use_reloader=False)

--- a/tdcosim/tdcosimapp.py
+++ b/tdcosim/tdcosimapp.py
@@ -175,7 +175,7 @@ def dashboard(args):
 		
 		appPath=os.path.join(baseDir,'dashboard','app.py')
 
-		os.system('python {} {} "{}" {} {} {}'.format(appPath,args.outputPath,args.pssePath,args.reducedMemory,args.nFiles,args.useDask))
+		os.system('python {} {} "{}" {} {} {} {}'.format(appPath,args.outputPath,args.pssePath,args.reducedMemory,args.nFiles,args.useDask,args.portNumber))
 	except:
 		raise
 
@@ -341,7 +341,8 @@ if __name__ == "__main__":
 	parser.add_argument('-b','--batchDir', type=str, help='Directory where individual config files for batch processing can be found')
 	parser.add_argument('-n','--nFiles', type=int,default=2, help='Number of simulation files to read for dashboard visualization')
 	parser.add_argument('-d','--useDask', type=str,default='false', help='Use Dask instead of Pandas for reading the results for dashboard visualization')
-
+	parser.add_argument('-port','--portNumber', type=int,default=8050, help='Specify the port number for the dashboard server')
+	
 	if len(sys.argv)==1:
 		print_help()
 	else:


### PR DESCRIPTION
This will allow users to optionally specify the port number for the dashboard:
`tdcosim dashboard -port 8060 -o "path/to/file-or-folder"`

a) A single user to launch multiple dashboards by changing the port number.
b) Multiple users to launch dashboards by using a different port.

_Note: If the user doesn't provide any port number. The default port of 8050 will be used._